### PR TITLE
Fix jruby example

### DIFF
--- a/examples/jruby-service/build.gradle
+++ b/examples/jruby-service/build.gradle
@@ -1,11 +1,13 @@
 buildscript {
     repositories {
         jcenter()
-        mavenLocal()
+        maven {
+          url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
-        classpath 'com.github.lookout:service-artifact-plugin:0.1.7'
+        classpath 'gradle.plugin.com.github.lookout:service-artifact-plugin:0.1.7'
     }
 }
 


### PR DESCRIPTION
- point maven to plugins.gradle.org
- fix classpath