### PR TITLE
Always call mergeServiceFiles() on JRuby jars

### DIFF
--- a/src/main/groovy/com/github/lookout/serviceartifact/lang/JRuby.groovy
+++ b/src/main/groovy/com/github/lookout/serviceartifact/lang/JRuby.groovy
@@ -107,6 +107,8 @@ class JRuby extends AbstractServiceExtension {
 
             dependsOn this.project.tasks.findByName('assemble')
 
+            mergeServiceFiles()
+
             jruby {
                 defaultMainClass()
                 defaultGems()

--- a/src/main/groovy/com/github/lookout/serviceartifact/lang/JRuby.groovy
+++ b/src/main/groovy/com/github/lookout/serviceartifact/lang/JRuby.groovy
@@ -107,6 +107,10 @@ class JRuby extends AbstractServiceExtension {
 
             dependsOn this.project.tasks.findByName('assemble')
 
+            /* This is necessary when using projects that use things like
+            Jackson's polymorphic deserialization support such as
+            DropWizard configured via META-INF/services entries that
+            need merging. There's almost no reason not to do this all the time. */
             mergeServiceFiles()
 
             jruby {


### PR DESCRIPTION
This is necessary when using projects that use things like
Jackson's polymorphic deserialization support such as
DropWizard configured via META-INF/services entries that
need merging. There's almost no reason not to do this all
the time.