### PR TITLE
Add a simple `publish` task 

### DIFF
--- a/src/main/groovy/com/github/lookout/serviceartifact/ServiceArtifactPlugin.groovy
+++ b/src/main/groovy/com/github/lookout/serviceartifact/ServiceArtifactPlugin.groovy
@@ -38,19 +38,25 @@ class ServiceArtifactPlugin implements Plugin<Project> {
         Task tarTask = project.task('serviceTar', type: Tar) {
             group GROUP_NAME
             description "Create a .tar.gz artifact containing the service"
-            dependsOn project.tasks.prepareServiceScripts
+            dependsOn prepareTask
         }
 
         Task zipTask = project.task('serviceZip', type: Zip) {
             group GROUP_NAME
             description "Create a .zip artifact containing the service"
-            dependsOn project.tasks.prepareServiceScripts
+            dependsOn prepareTask
         }
 
         Task assembleTask = project.task('assembleService') {
             group GROUP_NAME
             description "Assemble all the service artifacts"
-            dependsOn project.tasks.serviceZip, project.tasks.serviceTar
+            dependsOn zipTask, tarTask
+        }
+
+        Task publishTask = project.task('publish') {
+            group GROUP_NAME
+            description "Publish all our artifacts (uploadServiceArchives and uploadArchives)"
+            dependsOn project.tasks.uploadArchives, project.tasks.uploadServiceArchives
         }
 
         project.artifacts.add(ARCHIVES_CONFIG, zipTask)

--- a/src/test/groovy/com/github/lookout/serviceartifact/ServiceArtifactPluginSpec.groovy
+++ b/src/test/groovy/com/github/lookout/serviceartifact/ServiceArtifactPluginSpec.groovy
@@ -38,14 +38,13 @@ class ServiceArtifactPluginSpec extends Specification {
         project.service instanceof ServiceArtifactExtension
     }
 
-
     def "project should include the serviceTar task"() {
         given:
         Task t = project.tasks.findByName('serviceTar')
 
         expect:
         t instanceof Tar
-        t.group == 'Service Artifact'
+        t.group == ServiceArtifactPlugin.GROUP_NAME
     }
 
     def "project should include the serviceZip task"() {
@@ -54,7 +53,7 @@ class ServiceArtifactPluginSpec extends Specification {
 
         expect:
         t instanceof Zip
-        t.group == 'Service Artifact'
+        t.group == ServiceArtifactPlugin.GROUP_NAME
     }
 
     def "project should include a prepareServiceScripts task"() {
@@ -63,7 +62,7 @@ class ServiceArtifactPluginSpec extends Specification {
 
         expect:
         t instanceof Task
-        t.group == 'Service Artifact'
+        t.group == ServiceArtifactPlugin.GROUP_NAME
     }
 
     def "project should include a assembleService task"() {
@@ -72,7 +71,29 @@ class ServiceArtifactPluginSpec extends Specification {
 
         expect:
         t instanceof Task
-        t.group == 'Service Artifact'
+        t.group == ServiceArtifactPlugin.GROUP_NAME
+    }
+
+    @Issue('https://github.com/lookout/service-artifact-gradle-plugin/issues/22')
+    def "project should have a publish task"() {
+        given:
+        Task t = project.tasks.findByName('publish')
+
+        expect:
+        t instanceof Task
+        t.group == ServiceArtifactPlugin.GROUP_NAME
+        t.dependsOn.contains(project.tasks.findByName('uploadArchives'))
+        t.dependsOn.contains(project.tasks.findByName('uploadServiceArchives'))
+    }
+
+    @Ignore
+    @Issue('https://github.com/lookout/service-artifact-gradle-plugin/issues/24')
+    def "assembleService should have outputs"() {
+        given:
+        Task t = project.tasks.findByName('assembleService')
+
+        expect:
+        !t.outputs.files.isEmpty()
     }
 
     def "project should include a serviceArchives configuration"() {


### PR DESCRIPTION
The publish task will assume that some configuraiton for these two tasks has
already happened, and simply exists to provide an easy single task-point to
execute them

Fixes #22